### PR TITLE
Consume hermes from environment variable path on iOS

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -15,12 +15,13 @@ version = package['version']
 # sdks/.hermesversion
 hermestag_file = File.join(react_native_path, "sdks", ".hermesversion")
 build_from_source = ENV['BUILD_FROM_SOURCE'] === 'true'
+local_hermes_dir = ENV['REACT_NATIVE_OVERRIDE_HERMES_DIR']
 
 git = "https://github.com/facebook/hermes.git"
 
 abort_if_invalid_tarball_provided!
 
-source = compute_hermes_source(build_from_source, hermestag_file, git, version, react_native_path)
+source = compute_hermes_source(build_from_source, hermestag_file, git, version, react_native_path, local_hermes_dir)
 
 Pod::Spec.new do |spec|
   spec.name        = "hermes-engine"

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -30,7 +30,7 @@ end
 # - react_native_path: path to react native
 #
 # Returns: a properly configured source object
-def compute_hermes_source(build_from_source, hermestag_file, git, version, react_native_path)
+def compute_hermes_source(build_from_source, hermestag_file, git, version, react_native_path, local_hermes_dir)
     source = {}
 
     if ENV.has_key?('HERMES_ENGINE_TARBALL_PATH')
@@ -39,9 +39,10 @@ def compute_hermes_source(build_from_source, hermestag_file, git, version, react
         build_hermes_from_commit(source, git, ENV['HERMES_COMMIT'])
     elsif build_from_source
         if File.exist?(hermestag_file)
+            putsIfPodPresent("file exists!!!!")
             build_from_tagfile(source, git, hermestag_file)
         else
-            build_hermes_from_source(source, git)
+            build_hermes_from_source(source, git, local_hermes_dir)
         end
     elsif hermes_artifact_exists(release_tarball_url(version, :debug))
         use_release_tarball(source, version, :debug)
@@ -50,7 +51,7 @@ def compute_hermes_source(build_from_source, hermestag_file, git, version, react
     elsif hermes_artifact_exists(nightly_tarball_url(version).gsub("\\", ""))
         use_nightly_tarball(source, react_native_path, version)
     else
-        build_hermes_from_source(source, git)
+        build_hermes_from_source(source, git, local_hermes_dir)
     end
 
     return source
@@ -139,10 +140,15 @@ def nightly_tarball_url(version)
     return "http://oss.sonatype.org/service/local/artifact/maven/redirect\?#{params}"
 end
 
-def build_hermes_from_source(source, git)
+def build_hermes_from_source(source, git, local_hermes_dir)
     putsIfPodPresent('[Hermes] Installing hermes-engine may take slightly longer, building Hermes compiler from source...')
-    source[:git] = git
-    source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
+    if local_hermes_dir
+        source[:git] = "file://" + local_hermes_dir
+        source[:commit] = `cd #{local_hermes_dir} && git log --pretty --name-only | grep "commit" -m 1 | awk '{print $2}'`.strip
+    else
+        source[:git] = git
+        source[:commit] = `git ls-remote https://github.com/facebook/hermes main | cut -f 1`.strip
+    end
 end
 
 def build_hermes_from_commit(source, git, commit)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When making changes to hermes code, it is useful to be able to test on iOS. This PR adds the ability to consume a local copy of hermes on iOS builds.

* This can be used by running `REACT_NATIVE_OVERRIDE_HERMES_DIR=<path to local hermes directory> pod install`.
* Checks wether the environment variable REACT_NATIVE_OVERRIDE_HERMES_DIR is set. If it is, then it modifies the hermes-engine.podspec accordingly.
* The path is added to the podspec's source.git and the latest git commit from that path is added to the podspec's source.commit. {source: \<path from environment variable>, commit: \<latest commit after running git log on the environment variable path>}
* This adds a small inline script to retrieve the latest commit hash from the local hermes directory as mentioned above. Therefore, one needs to confirm that the active branch and the latest commit in that local hermes repository is the desired code we want to consume before running `REACT_NATIVE_OVERRIDE_HERMES_DIR=<path to local hermes directory> pod install`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [ADDED] - Consume se a local copy of hermes on iOS builds.

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [ADDED] - Consume se a local copy of hermes on iOS builds.

## Test Plan:
1. Clone hermes to a local directory.
2. Make a quick change to test.
3. Create a new react native app.
4. cd into the ios folder.
5. Add `export REACT_NATIVE_OVERRIDE_HERMES_DIR="<path to local source directory of hermes>"` to your environment – either inline `$ REACT_NATIVE_OVERRIDE_HERMES_DIR=<path to local source directory of hermes> bundle exec pod install` or to your terminal source profile `.bash_profile` for example. 
6. Execute `pod install` within `ios` folder.
7. Execute `npx react-native run-ios` to build and run the app.
8. Confirm you hermes change is present in the build.
